### PR TITLE
Original middleware is accessible through original

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function middleware(doIt, req, res) {
 
 module.exports = function (compiler, option) {
   var doIt = expressMiddleware(compiler, option);
-  return function*(next) {
+  var wrapper = function*(next) {
     var ctx = this;
     var req = this.req;
     var runNext = yield middleware(doIt, req, {
@@ -31,4 +31,6 @@ module.exports = function (compiler, option) {
       yield *next;
     }
   };
+  wrapper.original = doIt;
+  return wrapper;
 };


### PR DESCRIPTION
Example:

``` javascript
const middleware = webpackMiddleware(compiler, { ... });
app.use(middleware);
const content = middleware.original.fileSystem.readFileSync('index.html');
```

closes #7 
