### PR TITLE
Webpack middleware access through context

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function (compiler, option) {
   var doIt = expressMiddleware(compiler, option);
   return function*(next) {
     var ctx = this;
+    ctx.webpack = doIt;
     var req = this.req;
     var runNext = yield middleware(doIt, req, {
       end: function (content) {


### PR DESCRIPTION
Example:

``` javascript
const middleware = webpackMiddleware(compiler, { ... });
app.use(middleware);
app.get(function *() {
  this.body = this.webpack.fileSystem.readFileSync('index.html');
});
```

closes #7
