### PR TITLE
Support Koa 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ webpack dev middleware for koa
 [![node version][node-image]][node-url]
 
 
-[node-image]: https://img.shields.io/badge/node.js-%3E=_6.0.0-green.svg?style=flat-square
+[node-image]: https://img.shields.io/badge/node.js-%3E=_7.6.0-green.svg?style=flat-square
 [node-url]: http://nodejs.org/download/
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "http://github.com/yiminghe/koa-webpack-dev-middleware/issues"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=7.6.0"
   },
   "scripts": {
     "compile": "babel src --out-dir lib",

--- a/src/index.js
+++ b/src/index.js
@@ -19,14 +19,14 @@ function middleware(doIt, req, res) {
 module.exports = (compiler, option) => {
   const doIt = expressMiddleware(compiler, option);
 
-  function* koaMiddleware(next) {
+  function async koaMiddleware(next) {
     const ctx = this;
     const { req } = ctx;
     const locals = ctx.locals || ctx.state;
 
     ctx.webpack = doIt;
 
-    const runNext = yield middleware(doIt, req, {
+    const runNext = await middleware(doIt, req, {
       end(content) {
         ctx.body = content;
       },
@@ -37,7 +37,7 @@ module.exports = (compiler, option) => {
     });
 
     if (runNext) {
-      yield *next;
+      await next;
     }
   }
 


### PR DESCRIPTION
Fix #15 

This will require a major version bump.

I removed Nodes older than 6.0.0 from `package.json` as only v7.6.0 and later natively supports `async/await`.

If you still want to support older Nodes, there are two options:

1. Run the code through Babel and publish transpiled version. Maybe do a runtime check to see if native `async/await` is supported and require a transpiled version only then? Something like I had in [check-dependencies](https://github.com/mgol/check-dependencies/blob/e939d9b2c338662e193d71c222a6e8b97126a4a7/index.js). This would significantly increase the build overhead of this package, though.

2. Rewrite the code to not depend on `async/await` but use the Promise interface directly. This will not require any build step but will make the code less readable - Koa 2 is mainly about the niceties of the `async/await` syntax.


What do you think ?