### PR TITLE
Fix koa2 middleware signature

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,7 @@ function middleware(doIt, req, res) {
 module.exports = (compiler, option) => {
   const doIt = expressMiddleware(compiler, option);
 
-  async function koaMiddleware(next) {
-    const ctx = this;
+  async function koaMiddleware(ctx, next) {
     const { req } = ctx;
     const locals = ctx.locals || ctx.state;
 


### PR DESCRIPTION
Koa2 sets the context as the first parameter instead of using this as Koa1 did. This fixes the method signature.