### PR TITLE
support webpack5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pub": "npm publish && git push origin"
   },
   "licenses": "MIT",
-  "dependencies": {
-    "webpack-dev-middleware": "^1.10.0"
+  "peerDependencies": {
+    "webpack-dev-middleware": ">=1.10.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,10 @@ module.exports = (compiler, option) => {
       locals,
       setHeader() {
         ctx.set.apply(ctx, arguments);
-      }
+      },
+      getHeader() {
+        ctx.get.apply(ctx, arguments);
+      },
     });
 
     if (runNext) {


### PR DESCRIPTION
I noticed that issue #26 mentioned support for webpack 5, I tried adding `webpack-dev-middleware` as a peerDependencies and fix getHeader error. I tested it with both webpack 4 and webpack 5, and it performed well in my testing.

By the way, making `webpack-dev-middleware` as a peerDependencies might be a breaking change. If this PR is approved, should we release version 3.0.0?